### PR TITLE
Custom regexp

### DIFF
--- a/src/Classes/ExportLocalizations.php
+++ b/src/Classes/ExportLocalizations.php
@@ -21,12 +21,12 @@ class ExportLocalizations implements \JsonSerializable
     /**
      * @var string
      */
-    protected $phpRegex = '/^.+\.php$/i';
+    protected $phpRegex;
 
     /**
      * @var string
      */
-    protected $jsonRegex = '/^.+\.json$/i';
+    protected $jsonRegex;
 
     /**
      * @var string
@@ -37,6 +37,18 @@ class ExportLocalizations implements \JsonSerializable
      * @var string
      */
     protected $packageSeparator = '.';
+
+    /**
+     * ExportLocalizations constructor.
+     *
+     * @param string $phpRegex
+     * @param string $jsonRegex
+     */
+    public function __construct($phpRegex, $jsonRegex)
+    {
+        $this->phpRegex = $phpRegex;
+        $this->jsonRegex = $jsonRegex;
+    }
 
     /**
      * Method to return generate array with contents of parsed language files.

--- a/src/LaravelLocalizationServiceProvider.php
+++ b/src/LaravelLocalizationServiceProvider.php
@@ -18,8 +18,8 @@ class LaravelLocalizationServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->app->bind('export-localization', function () {
-            $phpRegex = config('laravel-localization.paths.file_regexp.php', '/^.+\.php$/i');
-            $jsonRegex = config('laravel-localization.paths.file_regexp.json', '/^.+\.json$/i');
+            $phpRegex = config('laravel-localization.file_regexp.php');
+            $jsonRegex = config('laravel-localization.file_regexp.json');
 
             return new ExportLocalizations($phpRegex, $jsonRegex);
         });

--- a/src/LaravelLocalizationServiceProvider.php
+++ b/src/LaravelLocalizationServiceProvider.php
@@ -18,7 +18,10 @@ class LaravelLocalizationServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->app->bind('export-localization', function () {
-            return new ExportLocalizations();
+            $phpRegex = config('laravel-localization.paths.file_regexp.php');
+            $jsonRegex = config('laravel-localization.paths.file_regexp.json');
+
+            return new ExportLocalizations($phpRegex, $jsonRegex);
         });
 
         /*

--- a/src/LaravelLocalizationServiceProvider.php
+++ b/src/LaravelLocalizationServiceProvider.php
@@ -18,8 +18,8 @@ class LaravelLocalizationServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->app->bind('export-localization', function () {
-            $phpRegex = config('laravel-localization.paths.file_regexp.php');
-            $jsonRegex = config('laravel-localization.paths.file_regexp.json');
+            $phpRegex = config('laravel-localization.paths.file_regexp.php', '/^.+\.php$/i');
+            $jsonRegex = config('laravel-localization.paths.file_regexp.json', '/^.+\.json$/i');
 
             return new ExportLocalizations($phpRegex, $jsonRegex);
         });

--- a/src/config/laravel-localization.php
+++ b/src/config/laravel-localization.php
@@ -88,14 +88,13 @@ return [
          * LARAVEL_LOCALIZATION_LANG_DIRS=resources/lang,Modules/Blog/Resources/lang
          */
         'lang_dirs' => [resource_path('lang')],
-
-        /*
+    ],
+    /*
          * You can customize the regexp for lang files to be able to exclude certain files.
          */
-        'file_regexp'  => [
-            'php' => '/^.+\.php$/i',
-            'json' => '/^.+\.json$/i',
-        ],
+    'file_regexp'  => [
+        'php' => '/^.+\.php$/i',
+        'json' => '/^.+\.json$/i',
     ],
 
 ];

--- a/src/config/laravel-localization.php
+++ b/src/config/laravel-localization.php
@@ -88,6 +88,14 @@ return [
          * LARAVEL_LOCALIZATION_LANG_DIRS=resources/lang,Modules/Blog/Resources/lang
          */
         'lang_dirs' => [resource_path('lang')],
+
+        /*
+         * You can customize the regexp for lang files to be able to exclude certain files.
+         */
+        'file_regexp'  => [
+            'php' => '/^.+\.php$/i',
+            'json' => '/^.+\.json$/i',
+        ],
     ],
 
 ];


### PR DESCRIPTION
In my app I didn't want to export all files and it was also not practical to split them into different dirs, so I made this customization.

```
    'paths'  => [

        /*
         * You can export more lang files then just files in resources/lang, for example
         *
         * In you .env file just add:
         * LARAVEL_LOCALIZATION_LANG_DIRS=resources/lang,Modules/Blog/Resources/lang
         */
        'lang_dirs' => [resource_path('lang')],

        'file_regexp'  => [
            'php' => '/^.*(foo|bar)\.php$/i',
            'json' => '/^.*(foo|bar)\.json$/i',
        ],
    ],
```