### PR TITLE
Backwards compatibility fix for v1.6.2

### DIFF
--- a/src/Classes/ExportLocalizations.php
+++ b/src/Classes/ExportLocalizations.php
@@ -44,7 +44,7 @@ class ExportLocalizations implements \JsonSerializable
      * @param string $phpRegex
      * @param string $jsonRegex
      */
-    public function __construct($phpRegex, $jsonRegex)
+    public function __construct($phpRegex = '/^.+\.php$/i', $jsonRegex = '/^.+\.json$/i')
     {
         $this->phpRegex = $phpRegex;
         $this->jsonRegex = $jsonRegex;

--- a/src/LaravelLocalizationServiceProvider.php
+++ b/src/LaravelLocalizationServiceProvider.php
@@ -18,8 +18,8 @@ class LaravelLocalizationServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->app->bind('export-localization', function () {
-            $phpRegex = config('laravel-localization.file_regexp.php');
-            $jsonRegex = config('laravel-localization.file_regexp.json');
+            $phpRegex = config('laravel-localization.file_regexp.php', '/^.+\.php$/i');
+            $jsonRegex = config('laravel-localization.file_regexp.json', '/^.+\.json$/i');
 
             return new ExportLocalizations($phpRegex, $jsonRegex);
         });


### PR DESCRIPTION
@kg-bot I've added the old values as defaults in both the constructor and when pulling the config to cover the following cases:

- Class is instantiated/extended as opposed to the bound one being used
- Class is requested when config file isn't present