### PR TITLE
add binding for ExportLocalizations class in service provider

### DIFF
--- a/src/Classes/ExportLocalizations.php
+++ b/src/Classes/ExportLocalizations.php
@@ -338,7 +338,7 @@ class ExportLocalizations implements \JsonSerializable
 
     public static function exportToArray()
     {
-        return app()->make(ExportLocalizations::class)->export()->toArray();
+        return app()->make(self::class)->export()->toArray();
     }
 
     protected static function executeCallback($strings)

--- a/src/Classes/ExportLocalizations.php
+++ b/src/Classes/ExportLocalizations.php
@@ -338,7 +338,7 @@ class ExportLocalizations implements \JsonSerializable
 
     public static function exportToArray()
     {
-        return (new self)->export()->toArray();
+        return app()->make(ExportLocalizations::class)->export()->toArray();
     }
 
     protected static function executeCallback($strings)

--- a/src/Classes/ExportLocalizations.php
+++ b/src/Classes/ExportLocalizations.php
@@ -338,7 +338,7 @@ class ExportLocalizations implements \JsonSerializable
 
     public static function exportToArray()
     {
-        return app()->make(self::class)->export()->toArray();
+        return \KgBot\LaravelLocalization\Facades\ExportLocalizations::export()->toArray();
     }
 
     protected static function executeCallback($strings)

--- a/src/LaravelLocalizationServiceProvider.php
+++ b/src/LaravelLocalizationServiceProvider.php
@@ -24,7 +24,7 @@ class LaravelLocalizationServiceProvider extends ServiceProvider
             return new ExportLocalizations($phpRegex, $jsonRegex);
         });
 
-        $this->app->alias( ExportLocalizations::class,'export-localization');
+        $this->app->alias(ExportLocalizations::class, 'export-localization');
 
         /*
          * Config

--- a/src/LaravelLocalizationServiceProvider.php
+++ b/src/LaravelLocalizationServiceProvider.php
@@ -17,12 +17,14 @@ class LaravelLocalizationServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->app->bind('export-localization', function () {
+        $this->app->bind(ExportLocalizations::class, function () {
             $phpRegex = config('laravel-localization.file_regexp.php', '/^.+\.php$/i');
             $jsonRegex = config('laravel-localization.file_regexp.json', '/^.+\.json$/i');
 
             return new ExportLocalizations($phpRegex, $jsonRegex);
         });
+
+        $this->app->alias( ExportLocalizations::class,'export-localization');
 
         /*
          * Config


### PR DESCRIPTION
I modified LaravelLocalizationServiceProvider to bind the regex parameters to the class constructor instead of the facade constructor. The facade is now created with as an alias.

Please feel to correct me as I am still discovering Laravel features.