### PR TITLE
Fix return type of export commands

### DIFF
--- a/src/Console/Commands/ExportMessages.php
+++ b/src/Console/Commands/ExportMessages.php
@@ -60,6 +60,6 @@ class ExportMessages extends Command
         $this->info('Messages exported to JavaScript file, you can find them at '.$filepath.DIRECTORY_SEPARATOR
                      .$filename);
 
-        return true;
+        return 0;
     }
 }

--- a/src/Console/Commands/ExportMessagesToFlat.php
+++ b/src/Console/Commands/ExportMessagesToFlat.php
@@ -60,6 +60,6 @@ class ExportMessagesToFlat extends Command
         $this->info('Messages exported to JavaScript file, you can find them at '.$filepath.DIRECTORY_SEPARATOR
                      .$filename);
 
-        return true;
+        return 0;
     }
 }


### PR DESCRIPTION
This solves a problem of the export commands breaking on CI or when piping multiple commands, since currently is exiting with 1, and it is detected as an error.

Laravel 7 now uses Symfony console 5.0 which expects integers for the command exit code.

From Laravel upgrade docs:

>Symfony Console, which is the underlying component that powers Artisan, expects all commands to return an integer. Therefore, you should ensure that any of your commands which return a value are returning integers:

```
public function handle()
{
    // Before...
    return true;

    // After...
    return 0;
}
```

https://laravel.com/docs/7.x/upgrade