### PR TITLE
Fix return type for jsonSerialize

### DIFF
--- a/src/Classes/ExportLocalizations.php
+++ b/src/Classes/ExportLocalizations.php
@@ -161,7 +161,7 @@ class ExportLocalizations implements \JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return self::executeCallback($this->strings);
     }


### PR DESCRIPTION
Return type of KgBot\LaravelLocalization\Classes\ExportLocalizations::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed,